### PR TITLE
Fixes #6 Line encoding issue in demo

### DIFF
--- a/DotNetKit.Wpf.AutoCompleteComboBox.Demo/Data/Person.cs
+++ b/DotNetKit.Wpf.AutoCompleteComboBox.Demo/Data/Person.cs
@@ -2083,7 +2083,7 @@ Zulma Avent
 ";
 
         static readonly IReadOnlyList<Person> allPersons =
-            source.Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries)
+            source.Split(new[] { Environment.NewLine , "\n" }, StringSplitOptions.RemoveEmptyEntries)
             .Select((name, i) => new Person(i + 1L, name))
             .ToArray();
 


### PR DESCRIPTION
This fixes an issue in the demo where if the file is encoded with \n line endings the whole list of people is turned into one person object with a very long name, and the library appears to be broken as filtering does not occur.